### PR TITLE
Allow 'x' icon to deselect all values

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -40,7 +40,7 @@ var DynamicSelect = function DynamicSelect(_ref) {
       onChange: function onChange(selected) {
         return _onChange(multiple ? selected.map(function (item) {
           return item.value;
-        }) : selected.value);
+        }) : selected && selected.value);
       }
     }, selectProps));
   }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const DynamicSelect = ({ cutoff, inputProps, items, labelProps, multiple, name, 
         options={items}
         value={value}
         multi={multiple}
-        onChange={selected => onChange(multiple ? selected.map(item => item.value) : selected.value)}
+        onChange={selected => onChange(multiple ? selected.map(item => item.value) : selected && selected.value)}
         {...selectProps}
       />
     )


### PR DESCRIPTION
React Select has an 'x' icon that deselects all values, but this is
broken in this library because it assumes that the onChange handler will
always have a value property

If the 'x' is clicked then `selected` is null and the existing code
breaks because null.value isn't a thing