### PR TITLE
Add default value for closeOnSelect

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41,7 +41,8 @@ var DynamicSelect = function DynamicSelect(_ref) {
         return _onChange(multiple ? selected.map(function (item) {
           return item.value;
         }) : selected.value);
-      }
+      },
+      closeOnSelect: !multiple
     }, selectProps));
   }
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const DynamicSelect = ({ cutoff, inputProps, items, labelProps, multiple, name, 
         value={value}
         multi={multiple}
         onChange={selected => onChange(multiple ? selected.map(item => item.value) : selected.value)}
+        closeOnSelect={!multiple}
         {...selectProps}
       />
     )


### PR DESCRIPTION
If we're in `multiple` mode then it makes sense to keep the dropdown
open when selecting items

This is still customisable — it can be overwritten using `selectProps`