### PR TITLE
wrap-radios-and-checkboxes-in-divs

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,31 +19,35 @@ const DynamicSelect = ({ cutoff, inputProps, items, labelProps, multiple, name, 
 
   if (multiple) {
     return items.map((item, index) =>
-      <label key={index} {...labelProps}>
-        <input
-          type='checkbox'
-          name={name}
-          checked={value.includes(item.value)}
-          onChange={event =>
-            event.target.checked ? onChange(value.concat(item.value)) : onChange(value.filter(x => x !== item.value))
-          }
-          {...inputProps}
-        /> {item.label}
-      </label>
+      <div>
+        <label key={index} {...labelProps}>
+          <input
+            type='checkbox'
+            name={name}
+            checked={value.includes(item.value)}
+            onChange={event =>
+              event.target.checked ? onChange(value.concat(item.value)) : onChange(value.filter(x => x !== item.value))
+            }
+            {...inputProps}
+          /> {item.label}
+        </label>
+      </div>
     )
   }
 
   return items.map((item, index) =>
-    <label key={index} {...labelProps}>
-      <input
-        type='radio'
-        name={name}
-        value={item.value}
-        checked={value === item.value}
-        onChange={_ => onChange(item.value)}
-        {...inputProps}
-      /> {item.label}
-    </label>
+    <div>
+      <label key={index} {...labelProps}>
+        <input
+          type='radio'
+          name={name}
+          value={item.value}
+          checked={value === item.value}
+          onChange={() => onChange(item.value)}
+          {...inputProps}
+        /> {item.label}
+      </label>
+    </div>
   )
 }
 


### PR DESCRIPTION
Wrap inputs in divs to ensure one input per line.

This is better UX as multiple radios/checkboxes on one line is difficult
to use. This does make this library more opinionated and less flexible
as you can now not have multiple inputs on one line (where you could do
either with CSS before), but this isn't necessarily a bad thing.